### PR TITLE
Add flags for repo and pr number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Arguments to diff any pr. `--pr` and `--repo` have been added which allow for
+  diffing other PRs and even other repos.
+
 ## [0.1.2] - 2022-11-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Options:
   -V, --version               Print version information
 ```
 
-When no args the tool will try to diff the current branch's PR.
+With no args, the tool will try to diff the current branch's PR.
 
 When provided a PR number will diff that PR. When provided a repo (requires a
 pr), will diff that repo's PR.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 A difftool extension to the GitHub CLI, [gh](https://cli.github.com/).
 
-Launches a difftool to show the differences of PRs. The files will be created in a
-temporary directory with the base branch version of the files prefixed with
-`base_`.
+Launches a difftool to show the differences of PRs. The files will be created
+in a temporary directory with the base branch version of the files prefixed
+with `base_`.
 
 ```shell
 Usage: gh-difftool [OPTIONS]
 
 Options:
   -t, --tool <DIFFTOOL>       The difftool command to run [env: DIFFTOOL=]
-      --repo <ORG/REPO_NAME>  The GitHub repo to diff, defaults to the GitHub remote of the current git repo
-      --pr <PR>               The PR to diff, defaults to the one associated with the current branch
+      --repo <ORG/REPO_NAME>  The GitHub repo to diff, defaults to the GitHub 
+                              remote of the current git repo
+      --pr <PR>               The PR to diff, defaults to the one associated 
+                              with the current branch
   -h, --help                  Print help information
   -V, --version               Print version information
 ```
@@ -27,6 +29,7 @@ For instance one can do:
 ```shell
 gh difftool --repo speedyleion/gh-difftool --pr 10
 ```
+
 from any repo and get the same result.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -2,19 +2,32 @@
 
 A difftool extension to the GitHub CLI, [gh](https://cli.github.com/).
 
-Launches a difftool to show the differences between the branch the PR is being
-merged into and the tip of the branch on GitHub. The files will be created in a
+Launches a difftool to show the differences of PRs. The files will be created in a
 temporary directory with the base branch version of the files prefixed with
 `base_`.
 
 ```shell
-Usage: gh difftool [OPTIONS]
+Usage: gh-difftool [OPTIONS]
 
 Options:
-  -t, --tool <DIFFTOOL>  The difftool command to run [env: DIFFTOOL=]
-  -h, --help             Print help information
-  -V, --version          Print version information
+  -t, --tool <DIFFTOOL>       The difftool command to run [env: DIFFTOOL=]
+      --repo <ORG/REPO_NAME>  The GitHub repo to diff, defaults to the GitHub remote of the current git repo
+      --pr <PR>               The PR to diff, defaults to the one associated with the current branch
+  -h, --help                  Print help information
+  -V, --version               Print version information
 ```
+
+When no args the tool will try to diff the current branch's PR.
+
+When provided a PR number will diff that PR. When provided a repo (requires a
+pr), will diff that repo's PR.
+
+For instance one can do:
+
+```shell
+gh difftool --repo speedyleion/gh-difftool --pr 10
+```
+from any repo and get the same result.
 
 ## Installation
 

--- a/src/gh_interface.rs
+++ b/src/gh_interface.rs
@@ -45,12 +45,6 @@ impl<C: Cmd> GhCli<C> {
         Self { command }
     }
 
-    pub fn local_change_set(&mut self) -> Result<ChangeSet> {
-        let pr = self.current_pr()?;
-        let repo = self.current_repo()?;
-        self.change_set(repo, pr)
-    }
-
     fn run_command<I, T>(&mut self, args: I) -> Result<String>
     where
         I: IntoIterator<Item = T>,
@@ -411,119 +405,6 @@ mod tests {
         assert_eq!(
             format!("{}", root_cause),
             "none of the git remotes configured for this repository point to a known GitHub host. To tell gh about a new GitHub host, please use `gh auth login`"
-        );
-    }
-
-    #[test]
-    fn look_up_local_change_set() {
-        // The intent isn't to verify the arguments passed, that was done in the individual
-        // functions we just want to ensure everything is plumbed up correctly to build the local
-        // repo
-        let mut mock = MockC::new();
-
-        for output in [
-            "{\"number\": 11}",
-            "{\"name\": \"some-repo\", \"owner\": {\"id\": \"MDQ6VXNlcjE0MDA1Mzk=\", \"login\": \"a_cool_owner\"} }",]
-            {
-            mock.expect_new_from_self().times(1).returning(|| {
-                let mut mock = MockC::new();
-                mock.expect_output().times(1).returning(|| {
-                    Ok(Output {
-                        status: ExitStatus::from_raw(0),
-                        stdout: output.as_bytes().to_vec(),
-                        stderr: vec![],
-                    })
-                });
-                mock.expect_arg().returning(|_| MockC::new());
-                mock.expect_stdout().returning(|_| MockC::new());
-                mock.expect_stderr().returning(|_| MockC::new());
-                mock
-            });
-        }
-        mock.expect_new_from_self().times(1).returning(|| {
-            let mut mock = MockC::new();
-            mock.expect_arg()
-                .with(eq(OsString::from(
-                    "/repos/a_cool_owner/some-repo/pulls/11/files",
-                )))
-                .times(1)
-                .returning(|_| MockC::new());
-            mock.expect_output().times(1).returning(|| {
-                Ok(Output {
-                    status: ExitStatus::from_raw(0),
-                    stdout: ONE_FILE.as_bytes().to_vec(),
-                    stderr: vec![],
-                })
-            });
-            mock.expect_arg().returning(|_| MockC::new());
-            mock.expect_stdout().returning(|_| MockC::new());
-            mock.expect_stderr().returning(|_| MockC::new());
-            mock
-        });
-        let mut gh = GhCli::new(mock);
-        assert_eq!(gh.local_change_set().unwrap(),
-                   ChangeSet {
-                       changes: vec![Change {
-                           filename: String::from("Cargo.toml"),
-                           raw_url: String::from("https://github.com/speedyleion/gh-difftool/raw/befb7bf69c3c8ba97c714d57c8dadd9621021c84/Cargo.toml"),
-                           patch: String::from("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\""),
-                       }]
-                   }
-        );
-    }
-    #[test]
-    fn look_up_local_pr_3() {
-        // The intent isn't to verify the arguments passed, that was done in the individual
-        // functions we just want to ensure everything is plumbed up correctly to build the local
-        // repo
-        let mut mock = MockC::new();
-
-        for output in [
-            "{\"number\": 3}",
-            "{ \"name\": \"what\", \"owner\": { \"id\": \"MDQ6VXNlcjE0MDA1Mzk=\", \"login\": \"why\" } }",]
-            {
-            mock.expect_new_from_self().times(1).returning(|| {
-                let mut mock = MockC::new();
-                mock.expect_output().times(1).returning(|| {
-                    Ok(Output {
-                        status: ExitStatus::from_raw(0),
-                        stdout: output.as_bytes().to_vec(),
-                        stderr: vec![],
-                    })
-                });
-                mock.expect_arg().returning(|_| MockC::new());
-                mock.expect_stdout().returning(|_| MockC::new());
-                mock.expect_stderr().returning(|_| MockC::new());
-                mock
-            });
-        }
-        mock.expect_new_from_self().times(1).returning(|| {
-            let mut mock = MockC::new();
-            mock.expect_arg()
-                .with(eq(OsString::from("/repos/why/what/pulls/3/files")))
-                .times(1)
-                .returning(|_| MockC::new());
-            mock.expect_output().times(1).returning(|| {
-                Ok(Output {
-                    status: ExitStatus::from_raw(0),
-                    stdout: ONE_FILE.as_bytes().to_vec(),
-                    stderr: vec![],
-                })
-            });
-            mock.expect_arg().returning(|_| MockC::new());
-            mock.expect_stdout().returning(|_| MockC::new());
-            mock.expect_stderr().returning(|_| MockC::new());
-            mock
-        });
-        let mut gh = GhCli::new(mock);
-        assert_eq!(gh.local_change_set().unwrap(),
-                   ChangeSet {
-                       changes: vec![Change {
-                           filename: String::from("Cargo.toml"),
-                           raw_url: String::from("https://github.com/speedyleion/gh-difftool/raw/befb7bf69c3c8ba97c714d57c8dadd9621021c84/Cargo.toml"),
-                           patch: String::from("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\""),
-                       }]
-                   }
         );
     }
 }

--- a/src/gh_interface.rs
+++ b/src/gh_interface.rs
@@ -82,13 +82,13 @@ impl<C: Cmd> GhCli<C> {
         ChangeSet::try_from(output.as_str())
     }
 
-    fn current_pr(&mut self) -> Result<usize> {
+    pub fn current_pr(&mut self) -> Result<usize> {
         let output = self.run_command(["pr", "view", "--json", "number"])?;
         let pr: Pr = serde_json::from_str(output.as_str())?;
         Ok(pr.number)
     }
 
-    fn current_repo(&mut self) -> Result<String> {
+    pub fn current_repo(&mut self) -> Result<String> {
         let output = self.run_command(["repo", "view", "--json", "owner,name"])?;
         let repo: Repo = serde_json::from_str(output.as_str())?;
         Ok(repo.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,4 +47,3 @@ fn main() -> Result<()> {
     }
     Ok(())
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ struct Cli {
     #[arg(short = 't', long = "tool", env = "DIFFTOOL")]
     difftool: Option<String>,
 
-    /// The repo to diff, defaults to the repo resolved with the `gh` command line
+    /// The GitHub repo to diff, defaults to the GitHub remote of the current git repo
     #[arg(long = "repo", requires = "pr", value_names = ["ORG/REPO_NAME"])]
     repo: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ struct Cli {
     difftool: Option<String>,
 
     /// The repo to diff, defaults to the repo resolved with the `gh` command line
-    #[arg(long = "repo", requires = "pr")]
+    #[arg(long = "repo", requires = "pr", value_names = ["ORG/REPO_NAME"])]
     repo: Option<String>,
 
     /// The PR to diff, defaults to the one associated with the current branch

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,14 @@ struct Cli {
     /// The difftool command to run
     #[arg(short = 't', long = "tool", env = "DIFFTOOL")]
     difftool: Option<String>,
+
+    /// The repo to diff, defaults to the repo resolved with the `gh` command line
+    #[arg(long = "repo", requires = "pr")]
+    repo: Option<String>,
+
+    /// The PR to diff, defaults to the one associated with the current branch
+    #[arg(long = "pr")]
+    pr: Option<usize>,
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
Add flags `--pr` and `--repo`.

These flags allow specifying which pr to run the difftool against and also which
repo.
