### PR TITLE
vendor ssl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cli/gh-extension-precompile@v1
         with: 
           build_script_override: "scripts/build_dist.sh"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: xt0rted/markdownlint-problem-matcher@v1
+      - uses: xt0rted/markdownlint-problem-matcher@v2
       - uses: DavidAnson/markdownlint-cli2-action@v7
         with:
           globs: "**/*.md"

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "no-duplicate-header": {
+        // Allow multiple "Added" sections in the changelog
+        "siblings_only": true
+    }
+  },
+
+  "globs": ["**/*.md"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2022-11-20
+
 ### Changed
 
 - Statically link in OpenSSL. Prior versions would link to OpenSSL causing
-  portability issues for some distro versions using OpenSSL 1.1.# and others
-  using OpenSSL 3.#.
+  portability issues for some distro versions using OpenSSL 1.1.# while
+  others ues OpenSSL 3.#.
 
 ## [0.1.3] - 2022-11-19
 
@@ -37,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release
 
-[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.3...HEAD
+[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/speedyleion/gh-difftool/releases/tag/v0.1.4
 [0.1.3]: https://github.com/speedyleion/gh-difftool/releases/tag/v0.1.3
 [0.1.2]: https://github.com/speedyleion/gh-difftool/releases/tag/v0.1.2
 [0.1.1]: https://github.com/speedyleion/gh-difftool/releases/tag/v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Statically link in OpenSSL. Prior versions would link to OpenSSL causing
+  portability issues for some distro versions using OpenSSL 1.1.# and others
+  using OpenSSL 3.#.
+
 ## [0.1.3] - 2022-11-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Statically link in OpenSSL. Prior versions would link to OpenSSL causing
-  portability issues for some distro versions using OpenSSL 1.1.# while
-  others ues OpenSSL 3.#.
+- Statically link in OpenSSL. Dynamically linking to OpenSSL was causing
+  portability issues. Some distro versions use OpenSSL 1.1.# while others use
+  OpenSSL 3.#.
 
 ## [0.1.3] - 2022-11-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gh-difftool"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.66"
 clap = { version = "4.0.18", features = ["derive", "env"] }
-reqwest = { version = "0.11.12", features = ["blocking"] }
+reqwest = { version = "0.11.12", features = ["blocking", "native-tls-vendored"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 tempfile = "3.3.0"


### PR DESCRIPTION
Vendor SSL to allow publishing a more portable version. 

Currently some distro versions have OpenSSL 1.1.# while others have OpenSSL 3.#.  Publishing would link to one version while distro versions may or may not have had that version available.