### PR TITLE
Fetch file diffs asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--name-only` flag which will output the filenames of the changed files to
   stdout. This is similar to the `gh pr diff --name-only` command.
 
+### Changed
+
+- The diffing logic has been updated to run asynchronously. This allows for
+  fetching other changes in the background while the difftool is open and being
+  looked at. The changes are still presented to the user in the same order as 
+  before.
+
 ## [0.1.4] - 2022-11-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The diffing logic has been updated to run asynchronously. This allows for
   fetching other changes in the background while the difftool is open and being
-  looked at. The changes are still presented to the user in the same order as 
+  looked at. The changes are still presented to the user in the same order as
   before.
 
 ## [0.1.4] - 2022-11-20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.66"
 clap = { version = "4.0.18", features = ["derive", "env"] }
+futures = { version = "0.3.25", default_features = false }
 reqwest = { version = "0.11.12", features = ["blocking", "native-tls-vendored"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 tempfile = "3.3.0"
+tokio = { version = "1.22.0", features = ["full"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -34,6 +34,6 @@ impl Cmd for Command {
     }
     fn new_from_self(&self) -> Self {
         let program = self.get_program();
-        Command::new(program)
+        Self::new(program)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,13 @@ mod cmd;
 mod diff;
 mod gh_interface;
 
-use crate::change_set::Change;
-use crate::diff::Diff;
+use crate::change_set::{Change, ChangeSet};
+use crate::diff::{Diff, Difftool};
 use anyhow::Result;
 use clap::Parser;
+use futures::stream::FuturesOrdered;
+use futures::StreamExt;
+use std::collections::VecDeque;
 use std::process::Command;
 
 #[derive(Parser)]
@@ -34,7 +37,8 @@ struct Cli {
     name_only: bool,
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let cli = Cli::parse();
     let difftool = cli.difftool.as_deref().unwrap_or("bcompare");
 
@@ -59,10 +63,72 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    diff(difftool, change_set).await?;
+    Ok(())
+}
+
+/// A thin wrapper around [Difftool::launch()]. It allows for a common future when there is nothing
+/// to diff
+async fn launch_difftool(difftool: Option<Difftool>) -> Result<()> {
+    if let Some(difftool) = difftool {
+        difftool.launch().await
+    } else {
+        Ok(())
+    }
+}
+
+/// Launches a difftool for each change in `change_set`.
+///
+/// Similar to git-difftool only one change will be opened at a time in the difftool. The difftool
+/// of the changes will be executed in the same order as the changes.
+///
+/// # Arguments
+/// * `difftool` - The command name of the difftool to use
+/// * `change_set` - The changes to run the difftool on
+///
+/// # Implementation Details
+/// In an effort to speed up performance `async` behavior has been done. The logic uses 2 queues:
+///
+/// 1. a queue to download and create the temporary diff files
+/// 2. a queue to launch the difftool on the next change ready for diffing
+///
+/// The reason for the 2 queues is to prevent launching multiple difftool instances. We only want
+/// one instance up at a time until the user dismisses it. While the difftool is up and has not
+/// been dismissed, the downloading and creation of temporary diff files will proceed.
+async fn diff(difftool: impl AsRef<str>, change_set: ChangeSet) -> Result<()> {
     let diff = Diff::new(difftool)?;
-    for change in change_set.changes {
-        let mut difftool = diff.difftool(&change)?;
-        difftool.launch()?;
+    {
+        let mut stream = FuturesOrdered::new();
+        for change in change_set.changes {
+            stream.push_back(diff.difftool(change));
+        }
+
+        // See https://tokio.rs/tokio/tutorial/select#resuming-an-async-operation on this pattern
+        // Initialize to done, because the `launch_difftool(None)` will return a consumed future.
+        let mut done = true;
+        let diff_future = launch_difftool(None);
+        tokio::pin!(diff_future);
+
+        let mut diffs = VecDeque::new();
+
+        loop {
+            tokio::select! {
+                Some(new_diff) = stream.next() => {
+                    diffs.push_back(new_diff?);
+                    // Be sure and set this back to false since the other branch will set to true
+                    // if the `diffs` had happened to be empty last time through.
+                    done = false;
+                },
+                _ = &mut diff_future, if !done => {
+                    if let Some(diffthing) = diffs.pop_front() {
+                        diff_future.set(launch_difftool(Some(diffthing)));
+                    } else {
+                        done = true;
+                    }
+                },
+                else => break,
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
Previously each change was processed serially. A change would be fetched
and then loaded into the difftool. No other changes were processed
during this time. Now changes are processed asynchronously, but still
presented to the user in the same order.
