### PR TITLE
Look up difftool in gitconfig

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,6 +3,10 @@
     "no-duplicate-header": {
         // Allow multiple "Added" sections in the changelog
         "siblings_only": true
+    },
+    "line-length": {
+        // don't mess with code blocks
+        "code_blocks": false
     }
   },
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The default difftool will be looked up through the git config. The `diff.tool`
+  config option will be used to determine the default tool. The `-t, --tool`
+  flag and the `GH_DIFFTOOL` environment variable still override the default.
+
+### Changed
+
+- The environment variable for the tool has been renamed to `GH_DIFFTOOL`.
+  Previously it was `DIFFTOOL`. The new name allows for namespacing to avoid
+  possible collision.
+- The `-t, --tool` and environment variable now expect the git name of
+  the difftool program. Previously these values expected the path of the
+  difftool program to run. For example: `bc` is the git difftool name for the
+  [Beyond Compare](https://scootersoftware.com/) tool. `bc` is now the value
+  that should be passed to `-t, --tool`. The Beyond Compare executable is
+  named `bcompare`.
+
 ## [0.1.5] - 2022-12-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.66"
 clap = { version = "4.0.18", features = ["derive", "env"] }
+displaydoc = "0.2.3"
 futures = { version = "0.3.25", default_features = false }
+git-config = "0.12.0"
+once_cell = "1.16.0"
 reqwest = { version = "0.11.12", features = ["blocking", "native-tls-vendored"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
@@ -19,3 +22,4 @@ httpmock = "0.6.6"
 mockall = "0.11.2"
 temp_testdir = "0.2.3"
 textwrap = "0.16.0"
+yare = "1.0.2"

--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ with `base_`.
 Usage: gh-difftool [OPTIONS]
 
 Options:
-  -t, --tool <DIFFTOOL>       The difftool command to run [env: DIFFTOOL=]
-      --repo <ORG/REPO_NAME>  The GitHub repo to diff, defaults to the GitHub 
-                              remote of the current git repo
-      --pr <PR>               The PR to diff, defaults to the one associated 
-                              with the current branch
+  -t, --tool <TOOL>           The tool to use for diffing [env: GH_DIFFTOOL=]
+      --repo <ORG/REPO_NAME>  The GitHub repo to diff, defaults to the GitHub remote of the current git repo
+      --pr <PR>               The PR to diff, defaults to the one associated with the current branch
+      --name-only             Show only the names of files that changed in a PR
   -h, --help                  Print help information
   -V, --version               Print version information
 ```
@@ -24,13 +23,11 @@ With no args, the tool will try to diff the current branch's PR.
 When provided a PR number will diff that PR. When provided a repo (requires a
 pr), will diff that repo's PR.
 
-For instance one can do:
+For instance one can do the following from anywhere and get a result.
 
 ```shell
 gh difftool --repo speedyleion/gh-difftool --pr 10
 ```
-
-from any repo and get the same result.
 
 ## Installation
 
@@ -43,27 +40,66 @@ gh extension install speedyleion/gh-difftool
 
 > Note: Current installs only support 64bit Linux.
 
-## Difftool
+## Options
 
-The default diff tool is `bcompare`. There is no good reason it is the default.
-It happened to be what I had on my system.
 
-The `-t, --tool` option or the environment variable `DIFFTOOL` can be set to
-specify the diff tool to use.
+`--name-only`: Print only the names of files that changed in a PR, to stdout.
 
-The name `DIFFTOOL` was chosen to be generic similar to `EDITOR`.
+`--pr`: The PR number to diff. When not specified the `gh` command line will be used to look up the current PR. An error
+will be output on stdout if this option is omitted and the current branch is not associated with a PR.
+
+`--repo`: The GitHub repository to diff, defaults to the GitHub remote of the current git repository.
+
+`-t, --tool`: The tool to use for diffing the files. This name should match those used by git's difftool command or a
+custom one that the user has set the `git.diff.path` value for.
+
+## Configuration
+
+By default, the tool to use will be derived from the current git configuration
+<https://git-scm.com/docs/git-difftool>.
+
+One can specify a tool to use via the command line argument `-t, --tool` or by the environment variable `GH_DIFFTOOL`.
+
+There are a handful of known difftools available in `gh-difftool`, (bc, bc3, bc4, meld, gvimdiff). These known tools
+assume that the executable is available in the `PATH`.
+
+When the difftool is not in the `PATH`, it can be specified via the `difftool.<tool>.path` git config option.
+
+```ini
+[difftool.sometool]
+    path = /path/to/some/difftool
+```
+
+> Note: `gh-difftool` does *not* support the `difftool.<tool>.cmd` or the `difftool.trustExitCode` git config options.
+> Exit codes are not trusted.
+
+### Unsupported difftools
+
+Only a handful of difftools supported by git are natively supported by `gh-difftool`. If your difftool of choice is not
+supported you can explicitly set the `difftool.<tool>.path` git config option as a workaround.
 
 The difftool will be invoked as :
 
 ```shell
-<tool> <base_version> <on_disk_version>
+<tool> <base_version> <pr_version>
 ```
 
-If this doesn't work with your tool of choice you'll want to wrap it in a
-launcher script or similar that matches this format.
+Where `<tool>` will be taken from `difftool.<tool>.path`. If this invocation format doesn't work with your tool of
+choice you'll want to wrap the tool in a launcher script or similar that matches this format. If the launcher script
+happens to not work for the git difftool then you can make a wrapper difftool that will be used only by `gh-difftool`
+and not by git.
+
+1. Set the environment variable `GH_DIFFTOOL` to the name of the wrapper difftool, e.g. `set GH_DIFFTOOL=wrappertool`
+2. Configure the `path` git config option for the wrapper difftool (often in `~/.gitconfig`)
+    ```ini
+    [difftool.wrappertool]
+        path = /path/to/the/wrapper/script
+    ```
+
+git will only use the `difftool.wrappertool.path` value if git is invoked with `wrappertool` as the git difftool. Thus
+this will allow `gh-difftool` to work and not have a negative side effect on git.
 
 ## Requires
 
 - The GitHub CLI, [gh](https://cli.github.com/)
 - The [patch](https://www.man7.org/linux/man-pages/man1/patch.1.html) utility
-- OpenSSL headers for building

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ current git repository.
 
 `-t, --tool`: The tool to use for diffing the files. This name should match
 those used by git's difftool command or a custom one that the user has set
-the `git.diff.path` value for.
+the `difftool.<tool>.path` value for.
 
 ## Configuration
 
 By default, the tool to use will be derived from the current git configuration
 <https://git-scm.com/docs/git-difftool>. The `diff.tool` git configuration
-option will be used to determine the tool. Similar to git if `diff.tool` is
-not set then `merge.tool` will be used. Unlike git, if no tool is set
+option will be used to determine the tool. Similar to git, if `diff.tool` is
+not set then `merge.tool` will be used. Unlike git, if neither option is set
 `gh-difftool` will report an error.
 
 Alternatively one can specify a tool to use via the command line argument `-t,

--- a/README.md
+++ b/README.md
@@ -42,41 +42,50 @@ gh extension install speedyleion/gh-difftool
 
 ## Options
 
-
 `--name-only`: Print only the names of files that changed in a PR, to stdout.
 
-`--pr`: The PR number to diff. When not specified the `gh` command line will be used to look up the current PR. An error
-will be output on stdout if this option is omitted and the current branch is not associated with a PR.
+`--pr`: The PR number to diff. When not specified the `gh` command line will be
+used to look up the current PR. An error will be output on stdout if this option
+is omitted and the current branch is not associated with a PR.
 
-`--repo`: The GitHub repository to diff, defaults to the GitHub remote of the current git repository.
+`--repo`: The GitHub repository to diff, defaults to the GitHub remote of the
+current git repository.
 
-`-t, --tool`: The tool to use for diffing the files. This name should match those used by git's difftool command or a
-custom one that the user has set the `git.diff.path` value for.
+`-t, --tool`: The tool to use for diffing the files. This name should match
+those used by git's difftool command or a custom one that the user has set
+the `git.diff.path` value for.
 
 ## Configuration
 
 By default, the tool to use will be derived from the current git configuration
-<https://git-scm.com/docs/git-difftool>.
+<https://git-scm.com/docs/git-difftool>. The `diff.tool` git configuration
+option will be used to determine the tool. Similar to git if `diff.tool` is
+not set then `merge.tool` will be used. Unlike git, if no tool is set
+`gh-difftool` will report an error.
 
-One can specify a tool to use via the command line argument `-t, --tool` or by the environment variable `GH_DIFFTOOL`.
+Alternatively one can specify a tool to use via the command line argument `-t,
+--tool` or by the environment variable `GH_DIFFTOOL`.
 
-There are a handful of known difftools available in `gh-difftool`, (bc, bc3, bc4, meld, gvimdiff). These known tools
-assume that the executable is available in the `PATH`.
+There are a handful of known difftools available in `gh-difftool`, (bc, bc3,
+bc4, meld, gvimdiff). These known tools assume that the executable is available
+in the `PATH`.
 
-When the difftool is not in the `PATH`, it can be specified via the `difftool.<tool>.path` git config option.
+When the difftool is not in the `PATH`, it can be specified via
+the `difftool.<tool>.path` git config option.
 
 ```ini
 [difftool.sometool]
     path = /path/to/some/difftool
 ```
 
-> Note: `gh-difftool` does *not* support the `difftool.<tool>.cmd` or the `difftool.trustExitCode` git config options.
-> Exit codes are not trusted.
+> Note: `gh-difftool` does *not* support the `difftool.<tool>.cmd` or
+> the `difftool.trustExitCode` git config options. Exit codes are not trusted.
 
 ### Unsupported difftools
 
-Only a handful of difftools supported by git are natively supported by `gh-difftool`. If your difftool of choice is not
-supported you can explicitly set the `difftool.<tool>.path` git config option as a workaround.
+Only a handful of difftools supported by git are natively supported
+by `gh-difftool`. If your difftool of choice is not supported you can explicitly
+set the `difftool.<tool>.path` git config option as a workaround.
 
 The difftool will be invoked as :
 
@@ -84,20 +93,25 @@ The difftool will be invoked as :
 <tool> <base_version> <pr_version>
 ```
 
-Where `<tool>` will be taken from `difftool.<tool>.path`. If this invocation format doesn't work with your tool of
-choice you'll want to wrap the tool in a launcher script or similar that matches this format. If the launcher script
-happens to not work for the git difftool then you can make a wrapper difftool that will be used only by `gh-difftool`
-and not by git.
+Where `<tool>` will be taken from `difftool.<tool>.path`. If this invocation
+format doesn't work with your tool of choice you'll want to wrap the tool in a
+launcher script or similar that matches this format. If the launcher script
+happens to not work for the git difftool then you can make a wrapper difftool
+that will be used only by `gh-difftool` and not by git.
 
-1. Set the environment variable `GH_DIFFTOOL` to the name of the wrapper difftool, e.g. `set GH_DIFFTOOL=wrappertool`
-2. Configure the `path` git config option for the wrapper difftool (often in `~/.gitconfig`)
+1. Set the environment variable `GH_DIFFTOOL` to the name of the wrapper
+   difftool, e.g. `set GH_DIFFTOOL=wrappertool`
+2. Configure the `path` git config option for the wrapper difftool (often
+   in `~/.gitconfig`)
+
     ```ini
     [difftool.wrappertool]
         path = /path/to/the/wrapper/script
     ```
 
-git will only use the `difftool.wrappertool.path` value if git is invoked with `wrappertool` as the git difftool. Thus
-this will allow `gh-difftool` to work and not have a negative side effect on git.
+git will only use the `difftool.wrappertool.path` value if git is invoked
+with `wrappertool` as the git difftool. This will allow `gh-difftool` to
+work and not have a negative side effect on git.
 
 ## Requires
 

--- a/src/git_config.rs
+++ b/src/git_config.rs
@@ -1,0 +1,284 @@
+//          Copyright Nick G 2022.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+use anyhow::Result;
+use git_config::File;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use tokio::process::Command;
+
+// Looking at the Git source code the main entry point is
+// https://github.com/git/git/blob/master/git-mergetool--lib.sh
+// This will call into the various files in https://github.com/git/git/tree/master/mergetools
+// to build up the command and arguments.
+// In order to support all of the options that git provides we're going to *start* with just a few
+// tool options
+//
+// Note: I haven't figured out how the config -> difftool maps to the `cmd` and `path` config
+// options.
+//
+
+static DIFFTOOLS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("bc", "bcompare");
+    m.insert("bc3", "bcompare");
+    m.insert("bc4", "bcompare");
+    m.insert("meld", "meld");
+    m.insert("gvimdiff", "gvimdiff");
+    m
+});
+
+#[derive(Debug, displaydoc::Display, Eq, PartialEq)]
+pub enum Error {
+    /// "{0}" is not a git repository
+    NotAGitRepository(PathBuf),
+    /// No difftool configured for git
+    NoDifftoolConfigured,
+    /// Unknown difftool {0}
+    UnknownDifftool(String),
+}
+
+impl std::error::Error for Error {}
+
+/// A difftool from git
+#[derive(Debug, Eq, PartialEq, Default)]
+pub struct Difftool {
+    tool: String,
+    program: String,
+}
+
+impl Difftool {
+    pub fn new(git_dir: impl AsRef<Path>, tool: Option<impl AsRef<str>>) -> Result<Self> {
+        let tool = match tool {
+            Some(tool) => tool.as_ref().to_string(),
+            None => get_config_difftool(&git_dir)?,
+        };
+
+        let program = get_difftool_program(&git_dir, &tool)?;
+
+        Ok(Self { tool, program })
+    }
+
+    pub async fn launch(&self, local: impl AsRef<OsStr>, remote: impl AsRef<OsStr>) -> Result<()> {
+        let mut command = Command::new(&self.program);
+        command.arg(local);
+        command.arg(remote);
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        command.output().await?;
+        // Some difftools, like bcompare, will return non zero status when there is a diff and 0
+        // only when there are no changes.  This prevents us from trusting the status
+        Ok(())
+    }
+}
+
+fn get_difftool_program(git_dir: impl AsRef<Path>, name: impl AsRef<str>) -> Result<String> {
+    let config = git_config(git_dir)?;
+    match config.string("difftool", Some(name.as_ref()), "path") {
+        Some(path) => Ok(path.to_string()),
+        None => Ok(lookup_known_tool_programs(&name)?),
+    }
+}
+
+fn lookup_known_tool_programs(tool: impl AsRef<str>) -> Result<String> {
+    let tool = tool.as_ref();
+    let program = DIFFTOOLS
+        .get(tool)
+        .ok_or_else(|| Error::UnknownDifftool(tool.to_string()))?;
+    Ok(program.to_string())
+}
+
+fn get_config_difftool(dir: impl AsRef<Path>) -> Result<String> {
+    let config = git_config(dir)?;
+    match config.string("diff", None, "tool") {
+        Some(tool) => Ok(tool.to_string()),
+        // Note: due to the global git config being found and the users diff setting being taken
+        // form that this None branch isn't unit tested.
+        None => {
+            // Similar to git, we fall back to the merge tool if it's available
+            match config.string("merge", None, "tool") {
+                Some(tool) => Ok(tool.to_string()),
+                None => Err(Error::NoDifftoolConfigured.into()),
+            }
+        }
+    }
+}
+
+/// Find the git directory, `.git`, for the provided directory
+///
+/// This will walk up from the provided `dir` looking for the `.git` directory.
+/// This does *not* properly handle `.git` files for worktrees and submodules
+///
+/// # Returns:
+/// The full path to the `.git` directory if found. None if not found.
+fn find_git_dir(dir: impl AsRef<Path>) -> Option<PathBuf> {
+    let dir = dir.as_ref();
+    for path in dir.ancestors() {
+        let git = path.join(".git");
+        if git.exists() {
+            return Some(git);
+        }
+    }
+    None
+}
+
+/// Get the git config for the repo at `dir`
+///
+/// # Arguments
+/// * `dir` - The directory or sub-directory to a git repo
+///
+/// # Returns
+/// The config `File` for the repo at `dir`.
+///
+/// # Error
+/// If `dir` is not for a git repository
+pub fn git_config(dir: impl AsRef<Path>) -> Result<File<'static>> {
+    let git_dir =
+        find_git_dir(&dir).ok_or_else(|| Error::NotAGitRepository(PathBuf::from(dir.as_ref())))?;
+    Ok(File::from_git_dir(git_dir)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env::current_dir;
+    use std::fs;
+    use temp_testdir::TempDir;
+    use yare::parameterized;
+
+    #[test]
+    fn found_git_dir_in_current_dir() {
+        let dir = current_dir().unwrap();
+        let expected = dir.join(".git");
+        assert_eq!(find_git_dir(dir), Some(expected));
+    }
+
+    #[test]
+    fn found_git_dir_in_nested_dir() {
+        let root_dir = current_dir().unwrap();
+        let expected = root_dir.join(".git");
+        let nested_dir = root_dir.join("src");
+
+        assert_eq!(find_git_dir(nested_dir), Some(expected));
+    }
+
+    #[test]
+    fn relative_path() {
+        let expected = PathBuf::from(".git");
+        let nested_dir = PathBuf::from("src");
+
+        assert_eq!(find_git_dir(nested_dir), Some(expected));
+    }
+
+    #[test]
+    fn getting_git_config() {
+        let temp = TempDir::default().permanent();
+        let git_dir = temp.join(".git");
+        let config_file = git_dir.join("config");
+        fs::create_dir_all(git_dir).unwrap();
+        fs::write(&config_file, "[user]\n    name = Me\n").unwrap();
+        let config = git_config(temp).unwrap();
+
+        assert_eq!(
+            config.string("user", None, "name").unwrap().to_string(),
+            "Me".to_string()
+        );
+    }
+
+    #[test]
+    fn found_difftool_in_config() {
+        let temp = TempDir::default().permanent();
+        let git_dir = temp.join(".git");
+        let config_file = git_dir.join("config");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(&config_file, "[diff]\n    tool = meld\n").unwrap();
+
+        assert_eq!(get_config_difftool(&temp).unwrap(), "meld".to_string());
+    }
+
+    #[test]
+    fn difftool_program_from_config() {
+        let temp = TempDir::default().permanent();
+        let git_dir = temp.join(".git");
+        let config_file = git_dir.join("config");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(
+            &config_file,
+            "[difftool.makebelieve]\n    path = some/random/path",
+        )
+        .unwrap();
+
+        assert_eq!(
+            get_difftool_program(&temp, "makebelieve").unwrap(),
+            "some/random/path".to_string()
+        );
+    }
+
+    #[test]
+    fn difftool_program_from_config_with_quotes() {
+        let temp = TempDir::default().permanent();
+        let git_dir = temp.join(".git");
+        let config_file = git_dir.join("config");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(&config_file, "[difftool.magic]\n    path = \"my/cool/dir\"").unwrap();
+
+        assert_eq!(
+            get_difftool_program(&temp, "magic").unwrap(),
+            "my/cool/dir".to_string()
+        );
+    }
+
+    #[parameterized(
+    bc = { "bc", "bcompare" },
+    bc3 = { "bc", "bcompare" },
+    bc4 = { "bc", "bcompare" },
+    meld = { "meld", "meld" },
+    gvimdiff = { "gvimdiff", "gvimdiff" },
+    )]
+    fn lookup_known_tool(tool: &str, program: &str) {
+        assert_eq!(
+            lookup_known_tool_programs(tool).unwrap(),
+            program.to_string()
+        );
+    }
+
+    #[test]
+    fn difftool_from_config_overrides_local() {
+        let temp = TempDir::default().permanent();
+        let git_dir = temp.join(".git");
+        let config_file = git_dir.join("config");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(&config_file, "[difftool.bc]\n    path = /does/not/exist").unwrap();
+
+        assert_eq!(
+            get_difftool_program(&temp, "bc").unwrap(),
+            "/does/not/exist".to_string()
+        );
+    }
+
+    #[parameterized(
+    bc = { "bc", "yes" },
+    madeup = { "madeup", "no" },
+    )]
+    fn new_difftool(tool: &str, program: &str) {
+        let temp = TempDir::default().permanent();
+        let git_dir = temp.join(".git");
+        let config_file = git_dir.join("config");
+        fs::create_dir_all(&git_dir).unwrap();
+        let contents = format!("[difftool.{tool}]\n    path = {program}");
+        fs::write(&config_file, &contents).unwrap();
+
+        assert_eq!(
+            Difftool::new(&temp, Some(tool)).unwrap(),
+            Difftool {
+                tool: tool.to_string(),
+                program: program.to_string()
+            }
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    let difftool = git_config::Difftool::new(std::env::current_dir()?, cli.tool.as_deref())?;
 
     let mut gh = gh_interface::GhCli::new(Command::new("gh"));
     let pr = match cli.pr {
@@ -64,6 +63,8 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Important, do this after the name only check as name only doesn't need a difftool
+    let difftool = git_config::Difftool::new(std::env::current_dir()?, cli.tool.as_deref())?;
     diff(difftool, change_set).await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ use std::process::Command;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    /// The difftool command to run
-    #[arg(short = 't', long = "tool", env = "DIFFTOOL")]
+    /// The tool to use for diffing
+    #[arg(short = 't', long = "tool", env = "GH_DIFFTOOL")]
     tool: Option<String>,
 
     /// The GitHub repo to diff, defaults to the GitHub remote of the current git repo


### PR DESCRIPTION
Previously the difftool needed to be passed in on the command line or
via an environment variable. Now the git config hierarchy will be
searched for the difftool to use.
