### PR TITLE
Fix issue of reusing consumed future

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -96,7 +96,7 @@ mod tests {
         let git_dir = dir.join(".git");
         let config = git_dir.join("config");
         fs::create_dir_all(&git_dir).unwrap();
-        fs::write(&config, "[difftool.bc]\n    path = bcompare").unwrap();
+        fs::write(&config, "[difftool.bc]\n    path = bcomp").unwrap();
         git_config::Difftool::new(&dir, Some("bc")).unwrap()
     }
 

--- a/src/git_config.rs
+++ b/src/git_config.rs
@@ -234,9 +234,9 @@ mod tests {
     }
 
     #[parameterized(
-    bc = { "bc", "bcompare" },
-    bc3 = { "bc", "bcompare" },
-    bc4 = { "bc", "bcompare" },
+    bc = { "bc", "bcomp" },
+    bc3 = { "bc", "bcomp" },
+    bc4 = { "bc", "bcomp" },
     meld = { "meld", "meld" },
     gvimdiff = { "gvimdiff", "gvimdiff" },
     )]

--- a/src/git_config.rs
+++ b/src/git_config.rs
@@ -25,9 +25,9 @@ use tokio::process::Command;
 
 static DIFFTOOLS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     let mut m = HashMap::new();
-    m.insert("bc", "bcompare");
-    m.insert("bc3", "bcompare");
-    m.insert("bc4", "bcompare");
+    m.insert("bc", "bcomp");
+    m.insert("bc3", "bcomp");
+    m.insert("bc4", "bcomp");
     m.insert("meld", "meld");
     m.insert("gvimdiff", "gvimdiff");
     m

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,7 @@ async fn diff(difftool: git_config::Difftool, change_set: ChangeSet) -> Result<(
                     if let Some(diffthing) = diffs.pop_front() {
                         diff_future.set(launch_difftool(Some(diffthing)));
                     } else {
+                        diff_future.set(launch_difftool(None));
                         done = true;
                     }
                 },


### PR DESCRIPTION
Use `bcomp` instead of `bcompare`. Per
https://www.scootersoftware.com/v4help/index.html?command_line_reference.html

> bcomp
>
> Launch this program from a version control system because it will wait
> for the comparison to complete before returning.
