### PR TITLE
Fix default Beyond Compare progam name on linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - BeyondCompare command on linux. When the default changed to `bcomp` this
-  required a symlink to `bcompare`, or similar workaround, for linux. Now 
-  `bcomp` will be attempted and if it doesn't exist then `bcompare` will be 
+  required a symlink to `bcompare`, or similar workaround, for linux. Now
+  `bcomp` will be attempted and if it doesn't exist then `bcompare` will be
   used.
- 
+
 ## [0.1.7] - 2022-12-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- BeyondCompare command on linux. When the default changed to `bcomp` this
+  required a symlink to `bcompare`, or similar workaround, for linux. Now 
+  `bcomp` will be attempted and if it doesn't exist then `bcompare` will be 
+  used.
+ 
 ## [0.1.7] - 2022-12-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.87"
 tempfile = "3.3.0"
 tokio = { version = "1.22.0", features = ["full"] }
 url = "2.3.1"
+which = "4.3.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/src/gh_interface.rs
+++ b/src/gh_interface.rs
@@ -151,10 +151,7 @@ mod tests {
         let mut mock = MockC::new();
         let stdout = stdout.to_string();
         let stderr = stderr.to_string();
-        let args = args
-            .iter()
-            .map(|s| String::from(*s))
-            .collect::<Vec<_>>();
+        let args = args.iter().map(|s| String::from(*s)).collect::<Vec<_>>();
         mock.expect_new_from_self().returning(move || {
             let mut mock = MockC::new();
             let args = args.clone();

--- a/src/gh_interface.rs
+++ b/src/gh_interface.rs
@@ -142,8 +142,8 @@ mod tests {
                 "/repos/speedyleion/gh-difftool/pulls/10/files",
             ],
             status,
-            stdout.as_ref(),
-            stderr.as_ref(),
+            stdout,
+            stderr,
         )
     }
 
@@ -152,7 +152,7 @@ mod tests {
         let stdout = stdout.to_string();
         let stderr = stderr.to_string();
         let args = args
-            .into_iter()
+            .iter()
             .map(|s| String::from(*s))
             .collect::<Vec<_>>();
         mock.expect_new_from_self().returning(move || {

--- a/src/git_config.rs
+++ b/src/git_config.rs
@@ -94,10 +94,7 @@ fn lookup_known_tool_program(tool: impl AsRef<str>) -> Result<String> {
 
 fn find_first_program(programs: &[&str]) -> Option<String> {
     programs.iter().fold(None, |found, current| {
-        found.or_else(|| {
-            which::which(current).map(|_| String::from(*current))
-                .ok()
-        })
+        found.or_else(|| which::which(current).map(|_| String::from(*current)).ok())
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,14 @@ async fn diff(difftool: git_config::Difftool, change_set: ChangeSet) -> Result<(
                     // if the `diffs` had happened to be empty last time through.
                     done = false;
                 },
-                _ = &mut diff_future, if !done => {
+                result = &mut diff_future, if !done => {
+                    //TODO need to make this error more useful. Getting errors
+                    // with no context isn't nice, but it's better than not
+                    // getting the errors.
+                    if let Err(error) = result {
+                        println!("{error:?}");
+                    }
+
                     if let Some(diffthing) = diffs.pop_front() {
                         diff_future.set(launch_difftool(Some(diffthing)));
                     } else {


### PR DESCRIPTION
A previous fix changed from `bcompare` to `bcomp` in order to work
correctly on Mac. Linux installs don't have `bcomp` so a symlink or
similar was required to work around the Mac fix. Now multiple program
names are specified in the defaults and the first one found is used.
