### PR TITLE
Add `--skip-to` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The `--skip-to` option which allows for one to start the diff from the given
+  file, skipping all files before the specified one.
+
+### Changed
+
+- The `--name-only` flag now takes into account the specified
+  `FILES` and limits output to only those provided in `FILES` when present.
+
 ## [0.1.8] - 2023-01-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ will be created in a temporary directory with the base branch version of the
 files prefixed with `base_`.
 
 ```shell
-Usage: gh-difftool [OPTIONS] [PR]
+Usage: gh-difftool [OPTIONS] [PR] [-- <FILES>...]
 
 Arguments:
   [PR]
@@ -17,6 +17,11 @@ Arguments:
           A pull request can be supplied as argument in any of the following formats:
           - by number, e.g. "123"
           - by URL, e.g. "https://github.com/OWNER/REPO/pull/123"
+
+  [FILES]...
+          Specific files to diff.
+          
+          When not provided all of the files that changed in the pull request will be diffed
 
 Options:
   -t, --tool <TOOL>
@@ -29,6 +34,9 @@ Options:
 
       --name-only
           Show only the names of files that changed in a pull request
+
+      --skip-to <SKIP_TO>
+          Start showing the diff for the given file, skipping all the files before it
 
   -h, --help
           Print help information (use `-h` for a summary)

--- a/tests/skip_to.rs
+++ b/tests/skip_to.rs
@@ -1,0 +1,54 @@
+//          Copyright Nick G 2023.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+use assert_cmd::Command;
+
+/// These tests require a network connection to github
+
+#[test]
+fn pr_10() {
+    let mut cmd = Command::cargo_bin("gh-difftool").unwrap();
+    let assert = cmd
+        .arg("--name-only")
+        .arg("--skip-to")
+        .arg("Cargo.toml")
+        .arg("10")
+        .arg("--repo")
+        .arg("speedyleion/gh-difftool")
+        .assert();
+    assert
+        .success()
+        .stdout("Cargo.toml\nREADME.md\nscripts/build_dist.h\n");
+}
+
+#[test]
+fn pr_4535_from_clap() {
+    let mut cmd = Command::cargo_bin("gh-difftool").unwrap();
+    let assert = cmd
+        .arg("--name-only")
+        .arg("--skip-to")
+        .arg("clap_complete/Cargo.toml")
+        .arg("4535")
+        .arg("--repo")
+        .arg("clap-rs/clap")
+        .assert();
+    assert.success().stdout("clap_complete/Cargo.toml\n");
+}
+
+#[test]
+fn non_existent_file() {
+    let mut cmd = Command::cargo_bin("gh-difftool").unwrap();
+    let assert = cmd
+        .arg("--name-only")
+        .arg("--skip-to")
+        .arg("non.existent")
+        .arg("10")
+        .arg("--repo")
+        .arg("speedyleion/gh-difftool")
+        .assert();
+    assert
+        .failure()
+        .stderr("Error: No such path 'non.existent' in the diff.\n");
+}


### PR DESCRIPTION
The `--skip-to` flag allows for one to start the diff from the given
file, skipping all the files before it.
