### PR TITLE
Add `--rotate-to` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `--skip-to` option which allows for one to start the diff from the given
   file, skipping all files before the specified one.
+- The `--rotate-to` option which allows for one to start the diff from the given
+  file, moving all files before the specified one to the end.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Options:
       --name-only
           Show only the names of files that changed in a pull request
 
+      --rotate-to <ROTATE_TO>
+          Start showing the diff for the given file, the files before it will move to end.
+          
+          Applied before `--skip-to`. This behavior deviates from `git-difftool` which
+          seems to ignore rotation when `--skip-to` is present.
+
       --skip-to <SKIP_TO>
           Start showing the diff for the given file, skipping all the files before it
 

--- a/tests/rotate_to.rs
+++ b/tests/rotate_to.rs
@@ -1,0 +1,55 @@
+//          Copyright Nick G 2023.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+use assert_cmd::Command;
+
+/// These tests require a network connection to github
+
+#[test]
+fn pr_10() {
+    let mut cmd = Command::cargo_bin("gh-difftool").unwrap();
+    let assert = cmd
+        .arg("--name-only")
+        .arg("--rotate-to")
+        .arg("Cargo.toml")
+        .arg("10")
+        .arg("--repo")
+        .arg("speedyleion/gh-difftool")
+        .assert();
+    assert.success().stdout(
+        "Cargo.toml\nREADME.md\nscripts/build_dist.h\n.github/workflows/release.yml\n.gitignore\n",
+    );
+}
+
+#[test]
+fn pr_4535_from_clap() {
+    let mut cmd = Command::cargo_bin("gh-difftool").unwrap();
+    let assert = cmd
+        .arg("--name-only")
+        .arg("--rotate-to")
+        .arg("clap_complete/Cargo.toml")
+        .arg("4535")
+        .arg("--repo")
+        .arg("clap-rs/clap")
+        .assert();
+    assert
+        .success()
+        .stdout("clap_complete/Cargo.toml\nCargo.lock\nCargo.toml\n");
+}
+
+#[test]
+fn non_existent_file() {
+    let mut cmd = Command::cargo_bin("gh-difftool").unwrap();
+    let assert = cmd
+        .arg("--name-only")
+        .arg("--rotate-to")
+        .arg("not.real")
+        .arg("10")
+        .arg("--repo")
+        .arg("speedyleion/gh-difftool")
+        .assert();
+    assert
+        .failure()
+        .stderr("Error: No such path 'not.real' in the diff.\n");
+}


### PR DESCRIPTION
The `--rotate-to` flag allows for one to start the diff from the given
file, moving all the files before it to the end.
