### PR TITLE
Slight code cleanup for `FILES`

### DIFF
--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -86,11 +86,8 @@ impl ChangeSet {
     /// * `files` - The files to keep the changes for
     pub fn filter_files<T: AsRef<str>>(&mut self, files: &[T]) -> &mut Self {
         let files = files.iter().map(T::as_ref).collect::<Vec<_>>();
-        self.changes = self
-            .changes
-            .drain(..)
-            .filter(|c| files.contains(&c.filename.as_str()))
-            .collect::<Vec<Change>>();
+        self.changes
+            .retain(|c| files.contains(&c.filename.as_str()));
         self
     }
 


### PR DESCRIPTION
Previously when filtering a diff by `FILES` a copy of the original files was creating using [`drain()`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.drain) and [`filter()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.filter). Now [`retain()`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.retain) is used to modify the original files. 

No performance metrics were done to compare one implementation to the other.
