### PR TITLE
Fix prs with more than 30 files only showing first 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- PRs with more than 30 files will now show all files in the difftool.
+
 ## [0.1.10] - 2023-01-28
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ futures = { version = "0.3.25", default_features = false }
 git-config = "0.12.0"
 itertools = "0.10.5"
 once_cell = "1.16.0"
+parse_link_header = "0.3.3"
 reqwest = { version = "0.11.12", features = ["blocking", "native-tls-vendored"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"

--- a/tests/name_only.rs
+++ b/tests/name_only.rs
@@ -34,3 +34,87 @@ fn pr_4535_from_clap() {
         .success()
         .stdout("Cargo.lock\nCargo.toml\nclap_complete/Cargo.toml\n");
 }
+
+// The test cases from rust-lang were found by using,
+// https://docs.github.com/en/graphql/overview/explorer
+// and walking through prs looking for ones that exceeded the 30 file page size
+// query {
+//   repository(owner:"rust-lang", name:"rust") {
+//     pullRequests(first:100 after:"Y3Vyc29yOnYyOpHOAAHobA==") {
+//       edges{
+//         node{
+//           changedFiles
+//           number
+//         }
+//       }
+//       pageInfo {
+//         endCursor
+//         startCursor
+//       }
+//     }
+//   }
+// }
+
+#[test]
+fn pr_426_from_rust() {
+    let files = [
+        "src/comp/front/lexer.rs",
+        "src/comp/front/parser.rs",
+        "src/comp/front/token.rs",
+        "src/comp/pretty/pprust.rs",
+        "src/test/compile-fail/bad-recv.rs",
+        "src/test/run-fail/linked-failure.rs",
+        "src/test/run-fail/task-comm-14.rs",
+        "src/test/run-fail/trivial-message2.rs",
+        "src/test/run-pass/acyclic-unwind.rs",
+        "src/test/run-pass/basic-1.rs",
+        "src/test/run-pass/basic-2.rs",
+        "src/test/run-pass/basic.rs",
+        "src/test/run-pass/comm.rs",
+        "src/test/run-pass/decl-with-recv.rs",
+        "src/test/run-pass/destructor-ordering.rs",
+        "src/test/run-pass/lazychan.rs",
+        "src/test/run-pass/many.rs",
+        "src/test/run-pass/obj-dtor.rs",
+        "src/test/run-pass/preempt.rs",
+        "src/test/run-pass/rt-circular-buffer.rs",
+        "src/test/run-pass/task-comm-0.rs",
+        "src/test/run-pass/task-comm-10.rs",
+        "src/test/run-pass/task-comm-11.rs",
+        "src/test/run-pass/task-comm-15.rs",
+        "src/test/run-pass/task-comm-16.rs",
+        "src/test/run-pass/task-comm-3.rs",
+        "src/test/run-pass/task-comm-4.rs",
+        "src/test/run-pass/task-comm-5.rs",
+        "src/test/run-pass/task-comm-6.rs",
+        "src/test/run-pass/task-comm-7.rs",
+        "src/test/run-pass/task-comm-8.rs",
+        "src/test/run-pass/task-comm-9.rs",
+        "src/test/run-pass/task-comm-chan-nil.rs",
+        "src/test/run-pass/task-comm.rs",
+        "src/test/run-pass/trivial-message.rs",
+        "", // Needed for the trailing newline
+    ];
+    let mut cmd = Command::cargo_bin("gh-difftool").unwrap();
+    cmd.arg("--name-only")
+        .arg("426")
+        .arg("--repo")
+        .arg("rust-lang/rust")
+        .assert()
+        .success()
+        .stdout(files.join("\n"));
+}
+
+#[test]
+fn pr_346_from_rust() {
+    let mut cmd = Command::cargo_bin("gh-difftool").unwrap();
+    let assert = cmd
+        .arg("--name-only")
+        .arg("346")
+        .arg("--repo")
+        .arg("rust-lang/rust")
+        .assert()
+        .success();
+    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
+    assert_eq!(stdout.lines().count(), 182);
+}


### PR DESCRIPTION
Previously only the first 30 files of a PR would be presented when using
difftool, now all of the changed files are shown.
