### PR TITLE
Fix deleted files failing to diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.11] - 2023-02-05
-
 ### Fixed
 
 - Diffing of deleted files. Deleted files now result in a comparison of the old
   file against an empty file.
+
+## [0.1.11] - 2023-02-05
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Diffing of deleted files. Deleted files now result in a comparison of the old
+  file against an empty file.
+
+### Fixed
+
 - PRs with more than 30 files will now show all files in the difftool.
 
 ## [0.1.10] - 2023-01-28

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -27,12 +27,12 @@ impl Change {
         P2: AsRef<Path>,
     {
         // This is not an ideal implementation, but it works for now.
-        // When the file is removed (deleted) the Github API results in a `raw_url` which points to
-        // the old version of the file, not an empty version. This kind of makes sense as an empty
-        // file doesn't exist, the file itself doesn't exit. The problem comes in that the consumers
-        // of Change happen to create the original and new files instead of letting change do it.
-        // Because of this lack of encapsulation, change will swap out the new version for the old
-        // version and write an empty new version
+        // When the file is removed (deleted) the Github API provides a `raw_url` which points to
+        // the old version of the file, not an empty version. This makes sense as an empty file is
+        // different than a file that doesn't exist. The problem comes in that the consumers of
+        // [`Change`] happen to create the original and new files instead of letting [`Change`] do
+        // it. Because of this lack of encapsulation, [`Change`] will swap out the new version for
+        // the old version and write an empty new version
         if self.status == "removed" {
             fs::copy(&src, &dest)?;
             fs::write(src, "")?;

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -515,7 +515,7 @@ mod tests {
             patch: diff.to_string(),
             status: String::from("removed"),
         };
-        let expected = format!("{EOL}line one{EOL}line two{EOL}line three{EOL}");
+        let expected = format!("\nline one\nline two\nline three\n");
         change.reverse_apply(&b, &a).unwrap();
         assert_eq!(fs::read(&a).unwrap(), expected.into_bytes());
     }

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -5,9 +5,9 @@
 
 //! Set of changes that goes from one version of files to another
 
-use std::fs;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::fs;
 use std::io::{Error, ErrorKind, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -36,7 +36,7 @@ impl Change {
         if self.status == "removed" {
             fs::copy(&src, &dest)?;
             fs::write(src, "")?;
-            return Ok(())
+            return Ok(());
         }
         let mut cmd = Command::new("patch");
         cmd.args([

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -5,6 +5,7 @@
 
 //! Set of changes that goes from one version of files to another
 
+use std::fs;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::io::{Error, ErrorKind, Write};
@@ -16,6 +17,7 @@ pub struct Change {
     pub filename: String,
     pub raw_url: String,
     pub patch: String,
+    pub status: String,
 }
 
 impl Change {
@@ -24,6 +26,18 @@ impl Change {
         P1: AsRef<Path>,
         P2: AsRef<Path>,
     {
+        // This is not an ideal implementation, but it works for now.
+        // When the file is removed (deleted) the Github API results in a `raw_url` which points to
+        // the old version of the file, not an empty version. This kind of makes sense as an empty
+        // file doesn't exist, the file itself doesn't exit. The problem comes in that the consumers
+        // of Change happen to create the original and new files instead of letting change do it.
+        // Because of this lack of encapsulation, change will swap out the new version for the old
+        // version and write an empty new version
+        if self.status == "removed" {
+            fs::copy(&src, &dest)?;
+            fs::write(src, "")?;
+            return Ok(())
+        }
         let mut cmd = Command::new("patch");
         cmd.args([
             "-R",
@@ -178,6 +192,7 @@ mod tests {
                 filename: (*f).to_owned(),
                 raw_url: raw_url.to_owned(),
                 patch: patch.to_owned(),
+                status: String::from("modified"),
             })
             .collect::<Vec<_>>()
     }
@@ -221,6 +236,7 @@ mod tests {
                     filename: String::from("Cargo.toml"),
                     raw_url: String::from("https://github.com/speedyleion/gh-difftool/raw/befb7bf69c3c8ba97c714d57c8dadd9621021c84/Cargo.toml"),
                     patch: String::from("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\""),
+                    status: String::from("modified"),
                 }]
             }
         );
@@ -247,17 +263,20 @@ mod tests {
               {
                 "filename": "Cargo.toml",
                 "raw_url": "stuff",
-                "patch": "more_stuff"
+                "patch": "more_stuff",
+                "status": "modified"
               },
               {
                 "filename": "yes/no/maybe.idk",
                 "raw_url": "sure",
-                "patch": "why not"
+                "patch": "why not",
+                "status": "modified"
               },
               {
                 "filename": "what/when/where.stuff",
                 "raw_url": "idk",
-                "patch": "I guess"
+                "patch": "I guess",
+                "status": "modified"
               }
             ]
         "#;
@@ -270,16 +289,19 @@ mod tests {
                         filename: String::from("Cargo.toml"),
                         raw_url: String::from("stuff"),
                         patch: String::from("more_stuff"),
+                        status: String::from("modified"),
                     },
                     Change {
                         filename: String::from("yes/no/maybe.idk"),
                         raw_url: String::from("sure"),
                         patch: String::from("why not"),
+                        status: String::from("modified"),
                     },
                     Change {
                         filename: String::from("what/when/where.stuff"),
                         raw_url: String::from("idk"),
                         patch: String::from("I guess"),
+                        status: String::from("modified"),
                     }
                 ]
             }
@@ -294,16 +316,19 @@ mod tests {
                     filename: String::from("Cargo.toml"),
                     raw_url: String::from("stuff"),
                     patch: String::from("more_stuff"),
+                    status: String::from("modified"),
                 },
                 Change {
                     filename: String::from("yes/no/maybe.idk"),
                     raw_url: String::from("sure"),
                     patch: String::from("why not"),
+                    status: String::from("modified"),
                 },
                 Change {
                     filename: String::from("what/when/where.stuff"),
                     raw_url: String::from("idk"),
                     patch: String::from("I guess"),
+                    status: String::from("modified"),
                 },
             ],
         };
@@ -318,11 +343,13 @@ mod tests {
                         filename: String::from("Cargo.toml"),
                         raw_url: String::from("stuff"),
                         patch: String::from("more_stuff"),
+                        status: String::from("modified"),
                     },
                     Change {
                         filename: String::from("yes/no/maybe.idk"),
                         raw_url: String::from("sure"),
                         patch: String::from("why not"),
+                        status: String::from("modified"),
                     },
                 ]
             }
@@ -413,6 +440,7 @@ mod tests {
             filename: "what/when/where.stuff".to_string(),
             raw_url: "idk".to_string(),
             patch: diff.to_string(),
+            status: String::from("modified"),
         };
         let expected = format!("{EOL}line one{EOL}line two{EOL}line three{EOL}");
         change.reverse_apply(&b, &a).unwrap();
@@ -437,6 +465,7 @@ mod tests {
             filename: "what/when/where.stuff".to_string(),
             raw_url: "idk".to_string(),
             patch: diff.to_string(),
+            status: String::from("modified"),
         };
         let expected = format!("{EOL}line one{EOL}line three{EOL}");
         change.reverse_apply(&b, &a).unwrap();
@@ -456,11 +485,38 @@ mod tests {
             filename: "what/when/where.stuff".to_string(),
             raw_url: "idk".to_string(),
             patch: diff.to_string(),
+            status: String::from("modified"),
         };
 
         let error = change.reverse_apply(&b, &a).unwrap_err();
         let root_cause = error.root_cause();
         let message = format!("{}", root_cause);
         assert!(message.starts_with(&message_start));
+    }
+
+    #[test]
+    fn file_removed() {
+        let temp = TempDir::default().permanent();
+        let a = temp.join("a");
+        let b = temp.join("b");
+        let raw_url_contents = dedent(
+            "
+            line one
+            line two
+            line three
+            ",
+        );
+        fs::write(&b, raw_url_contents).unwrap();
+
+        let diff = "@@ -1,3 +0,0 @@\n-line one\n-line two\n-line three";
+        let change = Change {
+            filename: "what/when/where.stuff".to_string(),
+            raw_url: "idk".to_string(),
+            patch: diff.to_string(),
+            status: String::from("removed"),
+        };
+        let expected = format!("{EOL}line one{EOL}line two{EOL}line three{EOL}");
+        change.reverse_apply(&b, &a).unwrap();
+        assert_eq!(fs::read(&a).unwrap(), expected.into_bytes());
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -124,6 +124,7 @@ mod tests {
             filename: "ignore_me".to_string(),
             raw_url: "sure".to_string(),
             patch: diff.to_string(),
+            status: "modified".to_string(),
         };
         let diff = Diff::new(difftool(&temp)).unwrap();
         let original = diff.create_temp_original(&change, b).unwrap();
@@ -145,6 +146,7 @@ mod tests {
             filename: "foo/bar/fish.ext".to_string(),
             raw_url: server.url("/one.c"),
             patch: "@@ -1,3 +1,3 @@\n doesn't matter".to_string(),
+            status: "modified".to_string(),
         };
         let diff = Diff::new(difftool(&temp)).unwrap();
         let new_file = diff.new_file_contents(&change).await.unwrap();
@@ -173,6 +175,7 @@ mod tests {
             filename: "foo/bar/fish.ext".to_string(),
             raw_url: server.url("/some_raw_url/path"),
             patch: "@@ -1,3 +1,3 @@\n doesn't matter".to_string(),
+            status: "modified".to_string(),
         };
         let diff = Diff::new(difftool(&temp)).unwrap();
         let new_file = diff.new_file_contents(&change).await.unwrap();

--- a/src/gh_interface.rs
+++ b/src/gh_interface.rs
@@ -329,6 +329,7 @@ mod tests {
                     filename: String::from("Cargo.toml"),
                     raw_url: String::from("https://github.com/speedyleion/gh-difftool/raw/befb7bf69c3c8ba97c714d57c8dadd9621021c84/Cargo.toml"),
                     patch: String::from("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\""),
+                    status: String::from("modified"),
                 }]
             }
         );
@@ -345,11 +346,13 @@ mod tests {
                         filename: String::from("Cargo.toml"),
                         raw_url: String::from("https://github.com/speedyleion/gh-difftool/raw/befb7bf69c3c8ba97c714d57c8dadd9621021c84/Cargo.toml"),
                         patch: String::from("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\""),
+                        status: String::from("modified"),
                     },
                     Change {
                         filename: String::from("src/main.rs"),
                         raw_url: String::from("https://github.com/speedyleion/gh-difftool/raw/befb7bf69c3c8ba97c714d57c8dadd9621021c84/src%2Fmain.rs"),
                         patch: String::from("@@ -1,4 +1,5 @@\n mod gh_interface;\n+mod patch;\n \n fn main() {\n     println!(\"Hello, world!\");"),
+                        status: String::from("modified"),
                     },
                 ]
             }


### PR DESCRIPTION
Previously deleted files would attempt a reverse apply. This would
fail with the patch CLI tool causing files after the deleted one to not
be displayed. Now deleted files will show up in the diff as the old file
against an empty file.
