### PR TITLE
Only do CI integration tests on ubuntu runners

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: r7kamura/rust-problem-matchers@v1
     - name: Build
-      run: cargo build --verbose
+      run: cargo build
 
   test:
     strategy:
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: r7kamura/rust-problem-matchers@v1
     - name: Run tests
-      run: cargo test ${{ matrix.bins }} --verbose
+      run: cargo test ${{ matrix.bins }}
 
   android-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,11 +31,9 @@ jobs:
           - os: macOS-latest
             bins: --bins
     runs-on: ${{ matrix.os }}
-    # Token needed for the higher level `gh ...` tests
+    # Token needed for the integration tests using the gh command line
     env:
       GH_TOKEN: ${{ github.token }}
-      if: matrix.os != 'ubuntu-latest'
-      BINS: --bins
     steps:
     - uses: actions/checkout@v4
     - uses: r7kamura/rust-problem-matchers@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,16 +15,32 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    # Token needed for the higher level `gh ...` tests
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
     - uses: actions/checkout@v4
     - uses: r7kamura/rust-problem-matchers@v1
     - name: Build
       run: cargo build --verbose
+
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: windows-latest
+            bins: --bins
+          - os: macOS-latest
+            bins: --bins
+    runs-on: ${{ matrix.os }}
+    # Token needed for the higher level `gh ...` tests
+    env:
+      GH_TOKEN: ${{ github.token }}
+      if: matrix.os != 'ubuntu-latest'
+      BINS: --bins
+    steps:
+    - uses: actions/checkout@v4
+    - uses: r7kamura/rust-problem-matchers@v1
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test ${{ matrix.bins }} --verbose
 
   android-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously the CI would do integration tests on all os variants. This
resulted in using up GH api quota when doing a lot of pr iteration. Now
only the ubuntu runs do integration tests.
