### PR TITLE
Fix renamed file diffs

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -150,8 +150,7 @@ mod tests {
             line three
             ",
         );
-        fs::write(&b, new).unwrap();
-        let expected = format!("{EOL}line one{EOL}line two{EOL}line three{EOL}");
+        fs::write(&b, &new).unwrap();
         let change = Change {
             filename: "ignore_me".to_string(),
             contents_url: "sure".to_string(),
@@ -165,7 +164,8 @@ mod tests {
             .to_str()
             .unwrap()
             .ends_with(&change.previous_filename.unwrap()));
-        assert_eq!(fs::read(&original).unwrap(), expected.into_bytes());
+        // A rename so the original should have the same contents
+        assert_eq!(fs::read(&original).unwrap(), new.into_bytes());
     }
 
     #[tokio::test]

--- a/src/gh_interface.rs
+++ b/src/gh_interface.rs
@@ -378,8 +378,9 @@ mod tests {
                 changes: vec![Change {
                     filename: String::from("Cargo.toml"),
                     contents_url: String::from("https://api.github.com/repos/speedyleion/gh-difftool/contents/Cargo.toml?ref=befb7bf69c3c8ba97c714d57c8dadd9621021c84"),
-                    patch: String::from("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\""),
+                    patch: Some("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\"".into()),
                     status: String::from("modified"),
+                    previous_filename: None,
                 }]
             }
         );
@@ -395,14 +396,16 @@ mod tests {
                     Change {
                         filename: String::from("Cargo.toml"),
                         contents_url: String::from("https://api.github.com/repos/speedyleion/gh-difftool/contents/Cargo.toml?ref=befb7bf69c3c8ba97c714d57c8dadd9621021c84"),
-                        patch: String::from("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\""),
+                        patch: Some("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\"".into()),
                         status: String::from("modified"),
+                        previous_filename: None,
                     },
                     Change {
                         filename: String::from("src/main.rs"),
                         contents_url: String::from("https://api.github.com/repos/speedyleion/gh-difftool/contents/src%2Fmain.rs?ref=befb7bf69c3c8ba97c714d57c8dadd9621021c84"),
-                        patch: String::from("@@ -1,4 +1,5 @@\n mod gh_interface;\n+mod patch;\n \n fn main() {\n     println!(\"Hello, world!\");"),
+                        patch: Some("@@ -1,4 +1,5 @@\n mod gh_interface;\n+mod patch;\n \n fn main() {\n     println!(\"Hello, world!\");".into()),
                         status: String::from("modified"),
+                        previous_filename: None,
                     },
                 ]
             }


### PR DESCRIPTION
Previously when a file was renamed the new name was displayed for the
old version of the file. If there was no diff in the rename the tool
would fail looking for the non existent `patch` field.
