### PR TITLE
Remove support for Android 5.x (Lollipop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.3] - 2025-05-11
 
+### Changed
+
+- Dropped support for Android 5.x (Lollipop). The new minimum supported Android
+  version is 6.0 (Marshmallow).
+
 ### Fixed
 
 - Submodule diffs causing early exit with error

--- a/scripts/build_dist.sh
+++ b/scripts/build_dist.sh
@@ -13,10 +13,10 @@ rustup target add ${CARGO_BUILD_TARGET}
 if [[ "${CARGO_BUILD_TARGET}" == *"android"* ]]; then
   underscore_target=$(echo "${CARGO_BUILD_TARGET}" | tr '-' '_')
   UNDERSCORE_TARGET=$(echo "${underscore_target}" | tr '[:lower:]' '[:upper:]')
-  export CC_${underscore_target}=/usr/local/lib/android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/linux-x86_64/bin/${CARGO_BUILD_TARGET}21-clang
-  export AR=/usr/local/lib/android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
-  export RANLIB=/usr/local/lib/android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib
-  export CARGO_TARGET_${UNDERSCORE_TARGET}_LINKER=/usr/local/lib/android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/linux-x86_64/bin/${CARGO_BUILD_TARGET}21-clang
+  export CC_${underscore_target}=/usr/local/lib/android/sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/${CARGO_BUILD_TARGET}23-clang
+  export AR=/usr/local/lib/android/sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
+  export RANLIB=/usr/local/lib/android/sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib
+  export CARGO_TARGET_${UNDERSCORE_TARGET}_LINKER=/usr/local/lib/android/sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/${CARGO_BUILD_TARGET}23-clang
 fi
 
 cargo build --release && mkdir dist && cp target/${CARGO_BUILD_TARGET}/release/gh-difftool"$ext" dist/gh-difftool_"$1"_"${TARGET}""$ext"


### PR DESCRIPTION
Previously the Android version of gh-difftool was built using Android
API level 21, providing support for Android 5.x (Lollipop). Now the
Android version of gh-difftool uses API level 32, supporting Android 6.x
(Marshmallow) and above. The github runners no longer come installed
with Android API level 21, resulting in this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Updated minimum Android version requirement from 5.x (Lollipop) to 6.0 (Marshmallow).

* **Chores**
  * Updated build dependencies and toolchain configuration for Android builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->