### PR TITLE
Add support for $MERGED in difftool invocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "mockall",
  "once_cell",
  "parse_link_header",
+ "regex",
  "serde",
  "serde_json",
  "shlex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ url = "2"
 which = "8"
 base64 = "0.22"
 shlex = "1"
+regex = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/git_config.rs
+++ b/src/git_config.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use gix_config::File;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
@@ -65,13 +65,22 @@ impl Difftool {
             .expect("No difftool command args set");
         let mut command = Command::new(program);
 
+        let re = regex::Regex::new(r"^.+gh-difftool[^/]+/").unwrap();
+        let remote_lossy = remote.as_ref().to_string_lossy();
+        let merged = OsString::from(re.replace(remote_lossy.as_ref(), "").into_owned());
+
         // We set the environment variables in case the preferred difftool uses them directly
-        command.envs([("LOCAL", local.as_ref()), ("REMOTE", remote.as_ref())]);
+        command.envs([
+            ("LOCAL", local.as_ref()),
+            ("REMOTE", remote.as_ref()),
+            ("MERGED", merged.as_os_str()),
+        ]);
 
         for arg in args {
             // We replace the environment variables with the local and remote
             // paths because Command is not a shell so will not expand them
             let arg = match arg.as_ref() {
+                "$MERGED" => merged.as_os_str(),
                 "$LOCAL" => local.as_ref(),
                 "$REMOTE" => remote.as_ref(),
                 _ => {


### PR DESCRIPTION
Some difftools, notably [difftastic](https://difftastic.wilfred.me.uk/introduction.html), use $MERGED in addition to $LOCAL and $REMOTE — see [difftastic's git integration docs](https://difftastic.wilfred.me.uk/git.html#difftool).

This PR adds support for it. I've been running this in my fork for a while and it works fine with difftastic.

I wasn't sure whether the $LOCAL/$REMOTE-only design was deliberate, so happy to adjust the approach (or close this) if there's context I'm missing.

If it is within the scope of this tool, let me know and I'll look into adding some tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Difftools now support a $MERGED placeholder, providing a normalized merged-path value for use in difftool commands (improves handling of temporary macOS path fragments).

* **Chores**
  * Added pattern-handling support to enable the new path-normalization logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->