### PR TITLE
Move name-only handling to separate module

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod change_set;
 mod diff;
 mod gh_interface;
 mod git_config;
+mod report;
 
 use crate::change_set::{Change, ChangeSet};
 use crate::diff::{Diff, Difftool};
@@ -95,10 +96,7 @@ async fn main() -> Result<()> {
     }
 
     if cli.name_only {
-        for change in change_set.changes {
-            let filename = change.filename;
-            println!("{filename}");
-        }
+        report::name_only(&change_set, std::io::stdout().lock())?;
         return Ok(());
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,44 @@
+//          Copyright Nick G 2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+//! Reports generated from a set of changes
+
+use crate::change_set::ChangeSet;
+use std::io::{self, Write};
+
+/// Write the name of each changed file on its own line.
+pub fn name_only(change_set: &ChangeSet, mut writer: impl Write) -> io::Result<()> {
+    for change in &change_set.changes {
+        writeln!(writer, "{}", change.filename)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::change_set::Change;
+
+    #[test]
+    fn name_only_writes_each_filename_on_its_own_line() {
+        let change_set = ChangeSet {
+            changes: vec![
+                Change {
+                    filename: "one.txt".to_string(),
+                    ..Change::default()
+                },
+                Change {
+                    filename: "path/two.txt".to_string(),
+                    ..Change::default()
+                },
+            ],
+        };
+        let mut output = Vec::new();
+
+        name_only(&change_set, &mut output).unwrap();
+
+        assert_eq!(output, b"one.txt\npath/two.txt\n");
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured reporting for the `--name-only` option.
  * Changed filenames are now displayed one per line for clearer, more consistent output.

* **Bug Fixes**
  * Improved handling of output errors when displaying changed filenames.

* **Tests**
  * Added coverage to verify correct output when multiple files are changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->