### PR TITLE
Add support for shortstat option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Options:
       --name-only
           Show only the names of files that changed in a pull request
 
+      --shortstat
+          Show only the number of changed files as well as number of added and
+          deleted lines
+
       --rotate-to <ROTATE_TO>
           Start showing the diff for the given file, the files before it will move to end.
           

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -18,6 +18,8 @@ pub struct Change {
     /// The previous_filename will be present for renamed files
     pub previous_filename: Option<String>,
     pub contents_url: String,
+    pub additions: usize,
+    pub deletions: usize,
     /// Patches are *not* present for files that are only renamed
     /// and large binary diffs
     pub patch: Option<String>,
@@ -215,6 +217,8 @@ mod tests {
             .map(|f| Change {
                 filename: (*f).to_owned(),
                 contents_url: contents_url.to_owned(),
+                additions: 0,
+                deletions: 0,
                 sha: "sha".into(),
                 patch: Some("patch".into()),
                 status: String::from("modified"),
@@ -261,6 +265,8 @@ mod tests {
                 changes: vec![Change {
                     filename: String::from("Cargo.toml"),
                     contents_url: String::from("https://api.github.com/repos/speedyleion/gh-difftool/contents/Cargo.toml?ref=befb7bf69c3c8ba97c714d57c8dadd9621021c84"),
+                    additions: 4,
+                    deletions: 0,
                     patch: Some("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\"".into()),
                     status: String::from("modified"),
                     previous_filename: None,
@@ -291,6 +297,8 @@ mod tests {
               {
                 "filename": "Cargo.toml",
                 "contents_url": "stuff",
+                "additions": 0,
+                "deletions": 0,
                 "patch": "more_stuff",
                 "status": "modified",
                 "sha": "sha1"
@@ -298,6 +306,8 @@ mod tests {
               {
                 "filename": "yes/no/maybe.idk",
                 "contents_url": "sure",
+                "additions": 0,
+                "deletions": 0,
                 "patch": "why not",
                 "status": "modified",
                 "sha": "sha2"
@@ -305,6 +315,8 @@ mod tests {
               {
                 "filename": "what/when/where.stuff",
                 "contents_url": "idk",
+                "additions": 0,
+                "deletions": 0,
                 "patch": "I guess",
                 "status": "modified",
                 "sha": "sha3"
@@ -319,6 +331,8 @@ mod tests {
                     Change {
                         filename: String::from("Cargo.toml"),
                         contents_url: String::from("stuff"),
+                        additions: 0,
+                        deletions: 0,
                         patch: Some("more_stuff".into()),
                         status: String::from("modified"),
                         previous_filename: None,
@@ -327,6 +341,8 @@ mod tests {
                     Change {
                         filename: String::from("yes/no/maybe.idk"),
                         contents_url: String::from("sure"),
+                        additions: 0,
+                        deletions: 0,
                         patch: Some("why not".into()),
                         status: String::from("modified"),
                         previous_filename: None,
@@ -335,6 +351,8 @@ mod tests {
                     Change {
                         filename: String::from("what/when/where.stuff"),
                         contents_url: String::from("idk"),
+                        additions: 0,
+                        deletions: 0,
                         patch: Some("I guess".into()),
                         status: String::from("modified"),
                         previous_filename: None,
@@ -352,6 +370,8 @@ mod tests {
                 Change {
                     filename: String::from("Cargo.toml"),
                     contents_url: String::from("stuff"),
+                    additions: 0,
+                    deletions: 0,
                     patch: Some("more_stuff".into()),
                     status: String::from("modified"),
                     previous_filename: None,
@@ -360,6 +380,8 @@ mod tests {
                 Change {
                     filename: String::from("yes/no/maybe.idk"),
                     contents_url: String::from("sure"),
+                    additions: 0,
+                    deletions: 0,
                     patch: Some("why not".into()),
                     status: String::from("modified"),
                     previous_filename: None,
@@ -368,6 +390,8 @@ mod tests {
                 Change {
                     filename: String::from("what/when/where.stuff"),
                     contents_url: String::from("idk"),
+                    additions: 0,
+                    deletions: 0,
                     patch: Some("I guess".into()),
                     status: String::from("modified"),
                     previous_filename: None,
@@ -385,6 +409,8 @@ mod tests {
                     Change {
                         filename: String::from("Cargo.toml"),
                         contents_url: String::from("stuff"),
+                        additions: 0,
+                        deletions: 0,
                         patch: Some("more_stuff".into()),
                         status: String::from("modified"),
                         previous_filename: None,
@@ -393,6 +419,8 @@ mod tests {
                     Change {
                         filename: String::from("yes/no/maybe.idk"),
                         contents_url: String::from("sure"),
+                        additions: 0,
+                        deletions: 0,
                         patch: Some("why not".into()),
                         status: String::from("modified"),
                         previous_filename: None,
@@ -486,6 +514,8 @@ mod tests {
         let change = Change {
             filename: "what/when/where.stuff".to_string(),
             contents_url: "idk".to_string(),
+            additions: 0,
+            deletions: 0,
             patch: Some(diff.to_string()),
             status: String::from("modified"),
             previous_filename: None,
@@ -513,6 +543,8 @@ mod tests {
         let change = Change {
             filename: "what/when/where.stuff".to_string(),
             contents_url: "idk".to_string(),
+            additions: 0,
+            deletions: 0,
             patch: Some(diff.to_string()),
             status: String::from("modified"),
             previous_filename: None,
@@ -535,6 +567,8 @@ mod tests {
         let change = Change {
             filename: "what/when/where.stuff".to_string(),
             contents_url: "idk".to_string(),
+            additions: 0,
+            deletions: 0,
             patch: Some(diff.to_string()),
             status: String::from("modified"),
             previous_filename: None,
@@ -565,6 +599,8 @@ mod tests {
         let change = Change {
             filename: "what/when/where.stuff".to_string(),
             contents_url: "idk".to_string(),
+            additions: 0,
+            deletions: 0,
             patch: Some(diff.to_string()),
             status: String::from("removed"),
             previous_filename: None,
@@ -593,6 +629,8 @@ mod tests {
         let change = Change {
             filename: "what/when/where.stuff".to_string(),
             contents_url: "idk".to_string(),
+            additions: 0,
+            deletions: 0,
             patch: None,
             status: String::from("renamed"),
             previous_filename: Some("foo/bar/baz/me.txt".into()),
@@ -615,6 +653,8 @@ mod tests {
         let change = Change {
             filename: "a/submodule".to_string(),
             contents_url: "idk".to_string(),
+            additions: 0,
+            deletions: 0,
             patch: Some(diff.to_string()),
             status: String::from("modified"),
             previous_filename: None,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -129,6 +129,8 @@ mod tests {
         let change = Change {
             filename: "ignore_me".to_string(),
             contents_url: "sure".to_string(),
+            additions: 0,
+            deletions: 0,
             patch: Some(diff.to_string()),
             status: "modified".to_string(),
             previous_filename: None,
@@ -157,6 +159,8 @@ mod tests {
         let change = Change {
             filename: "ignore_me".to_string(),
             contents_url: "sure".to_string(),
+            additions: 0,
+            deletions: 0,
             patch: Some(diff.to_string()),
             status: "renamed".to_string(),
             previous_filename: Some("new_filename".to_string()),
@@ -190,6 +194,8 @@ mod tests {
         let change = Change {
             filename: "foo/bar/fish.ext".to_string(),
             contents_url: server.url("/one.c"),
+            additions: 0,
+            deletions: 0,
             patch: Some("@@ -1,3 +1,3 @@\n doesn't matter".to_string()),
             status: "modified".to_string(),
             previous_filename: None,
@@ -223,6 +229,8 @@ mod tests {
         let change = Change {
             filename: "foo/bar/fish.ext".to_string(),
             contents_url: server.url("/some_raw_url/path"),
+            additions: 0,
+            deletions: 0,
             patch: Some("@@ -1,3 +1,3 @@\n doesn't matter".to_string()),
             status: "modified".to_string(),
             previous_filename: None,

--- a/src/gh_interface.rs
+++ b/src/gh_interface.rs
@@ -373,6 +373,8 @@ mod tests {
                 changes: vec![Change {
                     filename: String::from("Cargo.toml"),
                     contents_url: String::from("https://api.github.com/repos/speedyleion/gh-difftool/contents/Cargo.toml?ref=befb7bf69c3c8ba97c714d57c8dadd9621021c84"),
+                    additions: 4,
+                    deletions: 0,
                     patch: Some("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\"".into()),
                     status: String::from("modified"),
                     previous_filename: None,
@@ -392,6 +394,8 @@ mod tests {
                     Change {
                         filename: String::from("Cargo.toml"),
                         contents_url: String::from("https://api.github.com/repos/speedyleion/gh-difftool/contents/Cargo.toml?ref=befb7bf69c3c8ba97c714d57c8dadd9621021c84"),
+                        additions: 4,
+                        deletions: 0,
                         patch: Some("@@ -6,3 +6,7 @@ edition = \"2021\"\n [dev-dependencies]\n assert_cmd = \"2.0.4\"\n mockall = \"0.11.2\"\n+textwrap = \"0.15.1\"\n+\n+[dependencies]\n+patch = \"0.6.0\"".into()),
                         status: String::from("modified"),
                         previous_filename: None,
@@ -400,6 +404,8 @@ mod tests {
                     Change {
                         filename: String::from("src/main.rs"),
                         contents_url: String::from("https://api.github.com/repos/speedyleion/gh-difftool/contents/src%2Fmain.rs?ref=befb7bf69c3c8ba97c714d57c8dadd9621021c84"),
+                        additions: 1,
+                        deletions: 0,
                         patch: Some("@@ -1,4 +1,5 @@\n mod gh_interface;\n+mod patch;\n \n fn main() {\n     println!(\"Hello, world!\");".into()),
                         status: String::from("modified"),
                         previous_filename: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,10 @@ struct Cli {
     #[arg(long = "name-only")]
     name_only: bool,
 
+    /// Show only the number of changed files as well as number of added and deleted lines
+    #[arg(long = "shortstat", conflicts_with = "name_only")]
+    shortstat: bool,
+
     /// Start showing the diff for the given file, the files before it will move to end.
     ///
     /// Applied before `--skip-to`. This behavior deviates from `git-difftool` which
@@ -100,7 +104,12 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Important, do this after the name only check as name only doesn't need a difftool
+    if cli.shortstat {
+        report::shortstat(&change_set, std::io::stdout().lock())?;
+        return Ok(());
+    }
+
+    // Important, do this after the report checks as reports don't need a difftool
     let difftool = git_config::Difftool::new(std::env::current_dir()?, cli.tool.as_deref())?;
     diff(difftool, change_set).await?;
     Ok(())
@@ -217,7 +226,17 @@ fn parse_pr(pr: &str) -> Result<PullRequest> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::error::ErrorKind;
     use yare::parameterized;
+
+    #[test]
+    fn name_only_and_shortstat_conflict() {
+        let error = Cli::try_parse_from(["gh-difftool", "--name-only", "--shortstat"])
+            .err()
+            .expect("output reports should conflict");
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
 
     #[parameterized(
     empty = {""},

--- a/src/report.rs
+++ b/src/report.rs
@@ -16,10 +16,61 @@ pub fn name_only(change_set: &ChangeSet, mut writer: impl Write) -> io::Result<(
     Ok(())
 }
 
+/// Write a summary of the files and lines changed.
+pub fn shortstat(change_set: &ChangeSet, mut writer: impl Write) -> io::Result<()> {
+    let files = change_set.changes.len();
+    if files == 0 {
+        return Ok(());
+    }
+
+    let additions: usize = change_set
+        .changes
+        .iter()
+        .map(|change| change.additions)
+        .sum();
+    let deletions: usize = change_set
+        .changes
+        .iter()
+        .map(|change| change.deletions)
+        .sum();
+
+    write!(
+        writer,
+        " {files} file{} changed",
+        if files == 1 { "" } else { "s" }
+    )?;
+
+    if additions > 0 || deletions == 0 {
+        write!(
+            writer,
+            ", {additions} insertion{}(+)",
+            if additions == 1 { "" } else { "s" }
+        )?;
+    }
+    if deletions > 0 || additions == 0 {
+        write!(
+            writer,
+            ", {deletions} deletion{}(-)",
+            if deletions == 1 { "" } else { "s" }
+        )?;
+    }
+    writeln!(writer)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::change_set::Change;
+    use yare::parameterized;
+
+    fn change(filename: &str, additions: usize, deletions: usize) -> Change {
+        Change {
+            filename: filename.to_string(),
+            additions,
+            deletions,
+            ..Change::default()
+        }
+    }
 
     #[test]
     fn name_only_writes_each_filename_on_its_own_line() {
@@ -40,5 +91,27 @@ mod tests {
         name_only(&change_set, &mut output).unwrap();
 
         assert_eq!(output, b"one.txt\npath/two.txt\n");
+    }
+
+    #[parameterized(
+        aggregated = {&[("one.txt", 1, 2), ("two.txt", 3, 0)], " 2 files changed, 4 insertions(+), 2 deletions(-)\n"},
+        singular = {&[("one.txt", 1, 1)], " 1 file changed, 1 insertion(+), 1 deletion(-)\n"},
+        additions_only = {&[("one.txt", 2, 0)], " 1 file changed, 2 insertions(+)\n"},
+        deletions_only = {&[("one.txt", 0, 2)], " 1 file changed, 2 deletions(-)\n"},
+        no_line_changes = {&[("renamed.txt", 0, 0)], " 1 file changed, 0 insertions(+), 0 deletions(-)\n"},
+        empty = {&[], ""},
+    )]
+    fn shortstat_formats_changes(changes: &[(&str, usize, usize)], expected: &str) {
+        let change_set = ChangeSet {
+            changes: changes
+                .iter()
+                .map(|(filename, additions, deletions)| change(filename, *additions, *deletions))
+                .collect(),
+        };
+        let mut output = Vec::new();
+
+        shortstat(&change_set, &mut output).unwrap();
+
+        assert_eq!(output, expected.as_bytes());
     }
 }

--- a/tests/shortstat.rs
+++ b/tests/shortstat.rs
@@ -1,0 +1,22 @@
+//          Copyright Nick G 2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+use assert_cmd::cargo;
+
+/// This test requires a network connection to GitHub.
+#[test]
+fn pr_10() {
+    let mut cmd = cargo::cargo_bin_cmd!("gh-difftool");
+    let assert = cmd
+        .arg("--shortstat")
+        .arg("10")
+        .arg("--repo")
+        .arg("speedyleion/gh-difftool")
+        .assert();
+
+    assert
+        .success()
+        .stdout(" 5 files changed, 43 insertions(+), 4 deletions(-)\n");
+}


### PR DESCRIPTION
A new option `--shortstat`, similar to the git diff/difftool shortstat
option has been added. This option will provide a summary of the number
of files change, the number of lines added and the number of lines
deleted.
